### PR TITLE
Set Artifact Name so it can be overridden

### DIFF
--- a/meta/conf/layer.conf
+++ b/meta/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PATTERN_lora-gateway-os = "^${LAYERDIR}/"
 LAYERSERIES_COMPAT_lora-gateway-os = "thud"
 
 # Mender configuration
-MENDER_ARTIFACT_NAME = "lora-gateway-os-${DISTRO_VERSION}"
+MENDER_ARTIFACT_NAME ?= "lora-gateway-os-${DISTRO_VERSION}"
 
 # Set image overhead to 1
 IMAGE_OVERHEAD_FACTOR = "1"


### PR DESCRIPTION
This patch makes the artifact name a variable that can be overridden, allowing us to replace the artifact name with a jenkins build id or similar for CI/CD testing.